### PR TITLE
Refactor invoice PDF generation to use WeasyPrint

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,8 +1,11 @@
 from django.db import models
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.template.loader import render_to_string
+from django.contrib.staticfiles import finders
 from decimal import Decimal, ROUND_HALF_UP
-import io
+from pathlib import Path
+from urllib.parse import urlparse
 
 GCT_RATE = Decimal('0.15')
 
@@ -60,226 +63,63 @@ class Invoice(models.Model):
         return f"${v:,.2f}"
 
     def generate_general_pdf(self, overwrite: bool = True) -> None:
-        from PIL import Image, ImageDraw, ImageFont  # lazy import
+        try:
+            from weasyprint import HTML, default_url_fetcher
+        except ImportError as exc:
+            raise RuntimeError(
+                "WeasyPrint is required to generate invoice PDFs. Install the 'weasyprint' package to enable this feature."
+            ) from exc
 
-        scale = 1.6
+        def django_url_fetcher(url: str):
+            parsed = urlparse(url)
 
-        def scaled(value: int) -> int:
-            return max(1, int(value * scale))
+            if parsed.scheme in {"http", "https", "data"}:
+                return default_url_fetcher(url)
 
-        def load_font(name: str, size: int) -> ImageFont.FreeTypeFont:
-            try:
-                return ImageFont.truetype(name, size)
-            except Exception:
-                return ImageFont.load_default()
+            if settings.STATIC_URL and parsed.path.startswith(settings.STATIC_URL):
+                relative_path = parsed.path[len(settings.STATIC_URL):]
+                absolute_path = finders.find(relative_path)
+                if isinstance(absolute_path, (list, tuple)):
+                    absolute_path = absolute_path[0] if absolute_path else None
+                if absolute_path:
+                    return default_url_fetcher(Path(absolute_path).resolve().as_uri())
 
-        def right_align(x: int, y: int, text: str, font: ImageFont.FreeTypeFont, fill: str = "black") -> None:
-            bbox = draw.textbbox((0, 0), text, font=font)
-            draw.text((x - (bbox[2] - bbox[0]), y), text, font=font, fill=fill)
+            if settings.MEDIA_URL and parsed.path.startswith(settings.MEDIA_URL):
+                relative_path = parsed.path[len(settings.MEDIA_URL):]
+                media_path = (settings.MEDIA_ROOT / relative_path).resolve()
+                if media_path.exists():
+                    return default_url_fetcher(media_path.as_uri())
 
-        def wrap_description(text: str, font: ImageFont.FreeTypeFont, max_width: int) -> list[str]:
-            words = text.split()
-            lines: list[str] = []
-            current = ""
-            for word in words:
-                candidate = f"{current} {word}".strip()
-                bbox = draw.textbbox((0, 0), candidate, font=font)
-                if bbox[2] - bbox[0] <= max_width:
-                    current = candidate
-                else:
-                    if current:
-                        lines.append(current)
-                    current = word
-            if current:
-                lines.append(current)
-            return lines or [""]
+            fallback_path = (settings.BASE_DIR / parsed.path.lstrip("/")).resolve()
+            if fallback_path.exists():
+                return default_url_fetcher(fallback_path.as_uri())
 
-        page_w, page_h = scaled(1654), scaled(2339)  # approx A4 at higher resolution
-        background = Image.new("RGB", (page_w, page_h), color="#f8fafc")
-        draw = ImageDraw.Draw(background)
+            return default_url_fetcher(url)
 
-        font_title = load_font("DejaVuSerif-Bold.ttf", scaled(64))
-        font_heading = load_font("DejaVuSerif-Bold.ttf", scaled(40))
-        font_body = load_font("DejaVuSerif.ttf", scaled(34))
-        font_small = load_font("DejaVuSerif.ttf", scaled(30))
-        font_caption = load_font("DejaVuSerif.ttf", scaled(28))
-
-        outer_margin_x = int(0.06 * page_w)
-        outer_margin_y = int(0.05 * page_h)
-        card_radius = scaled(28)
-        card_bbox = (
-            outer_margin_x,
-            outer_margin_y,
-            page_w - outer_margin_x,
-            page_h - outer_margin_y,
-        )
-        draw.rounded_rectangle(
-            card_bbox,
-            radius=card_radius,
-            fill="white",
-            outline="#d0d7e2",
-            width=max(1, scaled(4)),
-        )
-
-        content_left = outer_margin_x + scaled(80)
-        content_right = page_w - outer_margin_x - scaled(80)
-        content_width = content_right - content_left
-        cursor_y = outer_margin_y + scaled(120)
-
-        # Logo and brand block
-        logo_path = settings.BASE_DIR / 'invoicegen' / 'resources' / 'logo.jpeg'
-        if not logo_path.exists():
-            alt = settings.BASE_DIR / 'resources' / 'logo.jpeg'
-            if alt.exists():
-                logo_path = alt
-
-        logo_max_width = int(content_width * 0.22)
-        brand_gap = scaled(40)
-        if logo_path.exists():
-            try:
-                logo = Image.open(logo_path).convert('RGBA')
-                ratio = min(logo_max_width / logo.width, 1.0)
-                logo = logo.resize((int(logo.width * ratio), int(logo.height * ratio)))
-                background.paste(logo, (content_left, cursor_y), logo if logo.mode == 'RGBA' else None)
-                text_x = content_left + logo.width + brand_gap
-            except Exception:
-                text_x = content_left
-        else:
-            text_x = content_left
-
-        brand_lines = [
-            ("STEPMATH AUTO LIMITED", font_heading),
-            ("(Certified Car Dealer)", font_caption),
-            ("94b Old Hope Road", font_body),
-            ("Kingston 6", font_body),
-            ("Tel: (876) 927-8281 / 978-0297", font_body),
-            ("Email: stepmathauto100@gmail.com", font_body),
+        logo_candidates = [
+            settings.BASE_DIR / "invoicegen" / "resources" / "logo.jpeg",
+            settings.BASE_DIR / "resources" / "logo.jpeg",
         ]
-        text_y = cursor_y
-        for text, font in brand_lines:
-            draw.text((text_x, text_y), text, font=font, fill="#111111")
-            text_y += font.size + scaled(6)
+        logo_path = next((p for p in logo_candidates if p.exists()), None)
 
-        cursor_y = max(text_y, cursor_y + scaled(240))
-
-        title_text = "ESTIMATE FOR REPAIRS"
-        title_bbox = draw.textbbox((0, 0), title_text, font=font_title)
-        draw.text(
-            ((page_w - (title_bbox[2] - title_bbox[0])) // 2, cursor_y),
-            title_text,
-            font=font_title,
-            fill="#111111",
+        html = render_to_string(
+            "invoices/detail.html",
+            {
+                "invoice": self,
+                "for_pdf": True,
+                "logo_src": logo_path.resolve().as_uri() if logo_path else None,
+            },
         )
 
-        cursor_y += font_title.size + scaled(50)
-        draw.line(
-            [(content_left, cursor_y), (content_right, cursor_y)],
-            fill="#111111",
-            width=max(1, scaled(3)),
-        )
-        cursor_y += scaled(40)
-
-        meta_left = content_left
-        meta_right = content_right
-        meta_top = cursor_y
-        meta_rows = [
-            ("Client", self.client.name),
-            ("Vehicle", self.vehicle or ""),
-            ("Lic#", self.lic_no or ""),
-            ("Chassis#", self.chassis_no or ""),
-        ]
-        for label, value in meta_rows:
-            draw.text((meta_left, cursor_y), f"{label}:", font=font_heading, fill="#111111")
-            draw.text((meta_left + scaled(200), cursor_y), value, font=font_body, fill="#111111")
-            cursor_y += font_body.size + scaled(12)
-
-        date_str = self.date.strftime("%-d-%b-%y") if hasattr(self.date, 'strftime') else str(self.date)
-        right_align(meta_right, meta_top, f"Date: {date_str}", font=font_body)
-
-        cursor_y += scaled(10)
-        draw.line(
-            [(content_left, cursor_y), (content_right, cursor_y)],
-            fill="#d0d7e2",
-            width=max(1, scaled(2)),
-        )
-        cursor_y += scaled(40)
-
-        table_header_height = scaled(60)
-        description_width = int(content_width * 0.55)
-        labour_col_right = content_left + description_width + int(content_width * 0.22)
-        parts_col_right = content_right
-
-        header_bbox = (content_left, cursor_y, content_right, cursor_y + table_header_height)
-        draw.rectangle(header_bbox, fill="#e2e8f0")
-        draw.text((content_left + scaled(20), cursor_y + scaled(12)), "Description", font=font_heading, fill="#111111")
-        right_align(parts_col_right, cursor_y + scaled(12), "Parts Cost", font=font_heading)
-        right_align(labour_col_right, cursor_y + scaled(12), "Labour Cost", font=font_heading)
-
-        cursor_y += table_header_height + scaled(10)
-
-        row_y = cursor_y
-        items_qs = list(self.items.all())
-        for item in items_qs:
-            desc_lines = wrap_description(item.description, font_small, description_width - scaled(40))
-            line_height = font_small.size + scaled(10)
-            row_height = max(line_height * len(desc_lines), line_height)
-
-            # row separator
-            draw.line(
-                [(content_left, row_y + row_height + scaled(10)), (content_right, row_y + row_height + scaled(10))],
-                fill="#e2e8f0",
-                width=max(1, scaled(2)),
-            )
-
-            text_y_line = row_y
-            for line in desc_lines:
-                draw.text((content_left + scaled(20), text_y_line), line, font=font_small, fill="#111111")
-                text_y_line += line_height
-
-            right_align(labour_col_right, row_y + scaled(5), self._money(item.labour_cost), font=font_small)
-            right_align(parts_col_right, row_y + scaled(5), self._money(item.parts_cost), font=font_small)
-
-            row_y += row_height + scaled(20)
-
-        if not items_qs:
-            draw.text((content_left + scaled(20), row_y), "No invoice items have been added yet.", font=font_small, fill="#111111")
-            row_y += font_small.size + scaled(20)
-
-        cursor_y = row_y + scaled(20)
-
-        totals_label_x = content_left + description_width - scaled(40)
-        totals = [
-            ("Cost", self._money(self.labour_subtotal), self._money(self.parts_subtotal)),
-            ("Plus 15% GCT", "", self._money(self.gct)),
-            ("Total Cost", "", self._money(self.total)),
-        ]
-
-        for label, labour_val, parts_val in totals:
-            draw.text((totals_label_x, cursor_y), label, font=font_heading, fill="#111111")
-            if labour_val:
-                right_align(labour_col_right, cursor_y, labour_val, font=font_heading)
-            if parts_val:
-                right_align(parts_col_right, cursor_y, parts_val, font=font_heading)
-            cursor_y += font_heading.size + scaled(24)
-
-        cursor_y += scaled(60)
-        draw.line(
-            [(content_left, cursor_y), (content_left + scaled(320), cursor_y)],
-            fill="#111111",
-            width=max(1, scaled(3)),
-        )
-        cursor_y += scaled(20)
-        draw.text((content_left, cursor_y), "ERROL DUHANEY", font=font_heading, fill="#111111")
-        cursor_y += font_heading.size + scaled(6)
-        draw.text((content_left, cursor_y), "MANAGING DIRECTOR", font=font_body, fill="#111111")
-
-        buf = io.BytesIO()
-        background.save(buf, format="PDF", resolution=300)
-        buf.seek(0)
+        pdf_content = HTML(
+            string=html,
+            base_url=str(settings.BASE_DIR),
+            url_fetcher=django_url_fetcher,
+        ).write_pdf()
 
         filename = f"invoice-{self.pk}-general.pdf"
         if not self.pdf_file or overwrite:
-            self.pdf_file.save(filename, ContentFile(buf.read()), save=True)
+            self.pdf_file.save(filename, ContentFile(pdf_content), save=True)
 
 
 class InvoiceItem(models.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.9.1
 django==5.2.6
 pillow==11.3.0
+weasyprint==62.3
 sqlparse==0.5.3

--- a/templates/invoices/detail.html
+++ b/templates/invoices/detail.html
@@ -6,7 +6,8 @@
   <div class="invoice-paper">
     <div class="invoice-header">
       <div class="brand-block">
-        <img src="{% static 'logo.jpeg' %}" alt="Stepmath Auto Limited" class="brand-logo">
+        {% static 'logo.jpeg' as default_logo %}
+        <img src="{{ logo_src|default:default_logo }}" alt="Stepmath Auto Limited" class="brand-logo">
         <div class="brand-text">
           <div class="brand-name">STEPMATH AUTO LIMITED</div>
           <div class="brand-meta">(Certified Car Dealer)</div>
@@ -83,16 +84,18 @@
     </div>
   </div>
 
-  <div class="actions mt-4">
-    <a href="{% url 'invoice_update' invoice.pk %}" class="btn btn-outline-secondary btn-sm">Edit Invoice</a>
-    <a href="{% url 'invoice_pdf' invoice.pk %}" class="btn btn-primary btn-sm">Download PDF</a>
-    <a href="{% url 'clients_detail' invoice.client.pk %}" class="btn btn-outline-secondary btn-sm">View Client</a>
-    <a href="{% url 'dashboard' %}" class="btn btn-outline-secondary btn-sm">Back to Dashboard</a>
-    <form action="{% url 'invoice_delete' invoice.pk %}" method="post" onsubmit="return confirm('Delete this invoice? This action cannot be undone.');">
-      {% csrf_token %}
-      <button type="submit" class="btn btn-danger btn-sm">Delete Invoice</button>
-    </form>
-  </div>
+  {% if not for_pdf %}
+    <div class="actions mt-4">
+      <a href="{% url 'invoice_update' invoice.pk %}" class="btn btn-outline-secondary btn-sm">Edit Invoice</a>
+      <a href="{% url 'invoice_pdf' invoice.pk %}" class="btn btn-primary btn-sm">Download PDF</a>
+      <a href="{% url 'clients_detail' invoice.client.pk %}" class="btn btn-outline-secondary btn-sm">View Client</a>
+      <a href="{% url 'dashboard' %}" class="btn btn-outline-secondary btn-sm">Back to Dashboard</a>
+      <form action="{% url 'invoice_delete' invoice.pk %}" method="post" onsubmit="return confirm('Delete this invoice? This action cannot be undone.');">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-danger btn-sm">Delete Invoice</button>
+      </form>
+    </div>
+  {% endif %}
 </div>
 
 <style>


### PR DESCRIPTION
## Summary
- replace the PIL-based invoice PDF builder with a WeasyPrint renderer that converts the existing invoice detail template into a PDF
- ensure static assets resolve during PDF generation and surface a helpful error when WeasyPrint is unavailable
- adjust the invoice detail template for shared PDF rendering and add WeasyPrint to project requirements

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cc5db554488333b8ca7b88fe469f93