### PR TITLE
Fix PDF layout width for WeasyPrint

### DIFF
--- a/templates/invoices/_detail_document.html
+++ b/templates/invoices/_detail_document.html
@@ -109,12 +109,15 @@
   .invoice-paper {
     background: #ffffff;
     color: #111111;
-    width: min(950px, 100%);
+    width: 100%;
+    max-width: 950px;
+    margin: 0 auto;
     padding: 3.5rem 3rem 2.75rem;
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 12px;
     box-shadow: 0 18px 45px rgba(15, 23, 42, 0.18);
     font-family: 'Times New Roman', serif;
+    box-sizing: border-box;
   }
 
   .invoice-header {

--- a/templates/invoices/detail_pdf.html
+++ b/templates/invoices/detail_pdf.html
@@ -28,6 +28,9 @@
       .invoice-paper {
         box-shadow: none;
         border: none;
+        max-width: none;
+        width: 100%;
+        margin: 0;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- ensure the invoice template uses a full-width, border-box layout so padding does not overflow the printable area
- override the PDF-specific stylesheet to remove the 950px cap and center margins so WeasyPrint pages stay within A4 bounds

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cc660639408333bff44df00d38386a