### PR TITLE
Adjust PDF invoice layout to span full page

### DIFF
--- a/templates/invoices/_detail_document.html
+++ b/templates/invoices/_detail_document.html
@@ -109,12 +109,15 @@
   .invoice-paper {
     background: #ffffff;
     color: #111111;
-    width: min(950px, 100%);
+    width: 100%;
+    max-width: 950px;
+    margin: 0 auto;
     padding: 3.5rem 3rem 2.75rem;
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 12px;
     box-shadow: 0 18px 45px rgba(15, 23, 42, 0.18);
     font-family: 'Times New Roman', serif;
+    box-sizing: border-box;
   }
 
   .invoice-header {
@@ -322,4 +325,29 @@
       width: 100%;
     }
   }
+
+  {% if for_pdf %}
+  .invoice-screen {
+    display: block;
+    padding: 0;
+    width: 100%;
+  }
+
+  .invoice-paper {
+    max-width: none;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 18mm 16mm 14mm;
+  }
+
+  .invoice-header {
+    align-items: stretch;
+  }
+
+  .brand-block {
+    align-items: flex-start;
+  }
+  {% endif %}
 </style>

--- a/templates/invoices/detail_pdf.html
+++ b/templates/invoices/detail_pdf.html
@@ -21,14 +21,6 @@
         font-family: 'Times New Roman', serif;
       }
 
-      .invoice-screen {
-        padding: 0;
-      }
-
-      .invoice-paper {
-        box-shadow: none;
-        border: none;
-      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add PDF-only overrides to stretch the invoice container and remove screen-only chrome when rendering with WeasyPrint
- simplify the PDF wrapper stylesheet now that PDF-specific layout adjustments live with the shared template

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cc660639408333bff44df00d38386a