### PR TITLE
Replace WeasyPrint with Playwright for invoice PDFs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.9.1
 django==5.2.6
 pillow==11.3.0
-weasyprint==62.3
+playwright==1.49.1
 sqlparse==0.5.3


### PR DESCRIPTION
## Summary
- replace the invoice PDF generator to render through Playwright/Chromium instead of WeasyPrint
- add clear runtime guidance when Playwright or its Chromium binary is missing
- update Python dependencies to require Playwright and drop WeasyPrint

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68cc6f5323f483338c748375aff697b4